### PR TITLE
[STEP 8] 비즈니스 구현 및 Usecase 구현

### DIFF
--- a/src/main/java/com/reservation/ticket/application/usecase/ConcertScheduleUsecase.java
+++ b/src/main/java/com/reservation/ticket/application/usecase/ConcertScheduleUsecase.java
@@ -1,0 +1,49 @@
+package com.reservation.ticket.application.usecase;
+
+import com.reservation.ticket.domain.command.ConcertScheduleCommand;
+import com.reservation.ticket.domain.command.QueueCommand;
+import com.reservation.ticket.domain.command.SeatCommand;
+import com.reservation.ticket.domain.service.ConcertScheduleService;
+import com.reservation.ticket.domain.service.QueueService;
+import com.reservation.ticket.domain.service.SeatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ConcertScheduleUsecase {
+
+    private final QueueService queueService;
+    private final SeatService seatService;
+    private final ConcertScheduleService concertScheduleService;
+
+    /**
+     * 1. 대기열 검증
+     * 2. 콘서트가 열리는 예약날자가 포함된 모든 스케줄을 조회한다.
+     */
+    public List<ConcertScheduleCommand.Get> selectConcertSchedulesByConcertId(Long userId, Long concertId) {
+        // 토큰 검증
+        QueueCommand.Get queue = queueService.verifyQueueByUserId(userId);
+        List<ConcertScheduleCommand.Get> concertSchedules =
+                concertScheduleService.selectAllConcertSchedulesByConcertId(concertId);
+        queueService.renewQueueExpirationDate(queue.token());
+        return concertSchedules;
+    }
+
+    /**
+     * 1. 대기열 상태 검증
+     * 2. 날짜로 선택된 콘서트 스케줄에서 연관된 좌석을 조회한다.
+     */
+    public ConcertScheduleCommand.GetForSeats selectSeatsByConcertScheduleId(Long userId, Long concertScheduleId) {
+        // 토큰 검증
+        QueueCommand.Get queue = queueService.verifyQueueByUserId(userId);
+        ConcertScheduleCommand.Get concertSchedule = concertScheduleService.getConcertScheduleById(concertScheduleId);
+        List<SeatCommand.Get> seats = seatService.selectSeatsByConcertScheduleId(concertSchedule.id());
+        // 토큰의 만료기간을 5분 늘려줌
+        queueService.renewQueueExpirationDate(queue.token());
+        return ConcertScheduleCommand.GetForSeats.of(concertSchedule, seats);
+    }
+}
+

--- a/src/main/java/com/reservation/ticket/application/usecase/ReservationUsecase.java
+++ b/src/main/java/com/reservation/ticket/application/usecase/ReservationUsecase.java
@@ -1,0 +1,48 @@
+package com.reservation.ticket.application.usecase;
+
+import com.reservation.ticket.domain.command.QueueCommand;
+import com.reservation.ticket.domain.command.ReservationCommand;
+import com.reservation.ticket.domain.service.QueueService;
+import com.reservation.ticket.domain.service.ReservationService;
+import com.reservation.ticket.domain.service.SeatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationUsecase {
+
+    private final ReservationService reservationService;
+    private final QueueService queueService;
+    private final SeatService seatService;
+
+    @Transactional
+    public ReservationCommand.Get makeReservation(ReservationCommand.Create create, Long userId) {
+        QueueCommand.Get queue = queueService.verifyQueueByUserId(userId);
+        // 예약을 진행한다.
+        ReservationCommand.Get reservation = reservationService.save(create, userId);
+        // 예약시 선택한 자리를 점유한다.
+        seatService.changeSeatOccupiedStatus(reservation.id(), create.seatIds());
+        queueService.renewQueueExpirationDate(queue.token());
+        return reservation;
+    }
+
+    @Transactional
+    @Scheduled(cron = "5 * * * * *", zone = "Asia/Seoul")
+    public void releaseOccupiedSeats() {
+        /**
+         *  `ACTIVE` 상태인 상위 10개의 예약을 가져와 미결재이며 현재시간과 비교하여 5분차이 시
+         *  상태값을 `CANCELLED` 로 변경
+         */
+        List<Long> cancelledReservationIds = reservationService.changeReservationStatusWhenNotPaidOnTime();
+        /**
+         *  예약으로 선점된 좌석을 다시 원상복구 한다.
+         */
+        seatService.recoverSeatOccupiedStatus(cancelledReservationIds);
+    }
+}
+

--- a/src/main/java/com/reservation/ticket/domain/service/QueueService.java
+++ b/src/main/java/com/reservation/ticket/domain/service/QueueService.java
@@ -1,0 +1,121 @@
+package com.reservation.ticket.domain.service;
+
+import com.reservation.ticket.domain.command.QueueCommand;
+import com.reservation.ticket.domain.entity.Queue;
+import com.reservation.ticket.domain.entity.UserAccount;
+import com.reservation.ticket.domain.enums.QueueStatus;
+import com.reservation.ticket.domain.repository.QueueRepository;
+import com.reservation.ticket.domain.repository.UserAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class QueueService {
+
+    private final QueueRepository queueRepository;
+    private final UserAccountRepository userAccountRepository;
+
+    @Transactional
+    public QueueCommand.Get createQueue(Long userId) {
+        UserAccount userAccount = userAccountRepository.findById(userId);
+        Queue queue = Queue.of(userAccount, generateToken(), QueueStatus.WAIT);
+        return QueueCommand.Get.from(queueRepository.save(queue));
+    }
+
+    @Transactional(readOnly = true)
+    public List<QueueCommand.Get> selectQueueByStatus(QueueStatus status) {
+        return queueRepository.findAllByQueueStatus(status).stream()
+                .map(QueueCommand.Get::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<QueueCommand.Get> selectQueueByStatusPerLimit(QueueStatus status, int limit) {
+        return queueRepository.findAllByQueueStatusPerLimit(status, limit).stream()
+                .map(QueueCommand.Get::from)
+                .toList();
+    }
+
+    public QueueCommand.Get getQueueByUserId(Long userId) {
+        Queue queue = getQueue(userId);
+        return QueueCommand.Get.from(queue);
+    }
+
+    @Transactional
+    public void expireQueueByChangingStatus(Long userId) {
+        Queue queue = getQueue(userId);
+        queue.changeStatus(QueueStatus.EXPIRED);
+    }
+
+    public QueueCommand.Get verifyQueueByUserId(Long userId) {
+        Queue queue = getQueue(userId);
+        // ACTIVE 가 아니면 예외발생
+        queue.verifyQueueStatus();
+        return QueueCommand.Get.from(queue);
+    }
+
+    @Transactional
+    public void renewQueueExpirationDate(String token) {
+        Queue queue = queueRepository.findByToken(token);
+        queue.extendShouldExpiredAt();
+    }
+
+    @Transactional
+    public QueueCommand.Get renewExpirationDate(Long userId) {
+        Queue queue = getQueue(userId);
+        queue.verifyQueueStatus();
+        queue.extendShouldExpiredAt();
+        return QueueCommand.Get.from(queue);
+    }
+
+    private Queue getQueue(Long userId) {
+        UserAccount userAccount = userAccountRepository.findById(userId);
+        return queueRepository.findByToken(userAccount.getToken());
+    }
+
+    /**
+     *  스케줄러 작업
+     *   - ACTIVE 상태인 대기열을 검색하여 만료시간을 현재시간과 비교하여 5분이 초과했다면 EXPIRED 로 상태를 변경
+     *   - 제한된 인원(30명)을 기준으로 현재 ACTIVE 상태인 대기열 목록과 비교하여
+     *      WAIT 상태인 대기열을 ACTIVE 로 변경
+     */
+    @Transactional
+    @Scheduled(cron = "5 * * * * *", zone = "Asia/Seoul")
+    public void changeTokenStatusExpired() {
+        // ACTIVE 상태의 대기열을 EXPIRED 로 변경하는 작업
+        List<Queue> queuesAsActive = queueRepository.findAllByQueueStatus(QueueStatus.ACTIVE);
+        // ACTIVE 상태의 사용자가 한명도 없을때 리스트 확인
+        if (!queuesAsActive.isEmpty()) {
+            queuesAsActive.forEach(queue -> {
+                // 만료시간이 현재시간 기준 5분 초과시 `EXPIRED` 로 변경
+                if (queue.getShouldExpiredAt().plusMinutes(5).isBefore(LocalDateTime.now())) {
+                    queue.changeStatus(QueueStatus.EXPIRED);
+                }
+            });
+        }
+
+        // ACTIVE 상태의 대기열을 EXPIRED 로 변경하는 작업
+        // 30명으로 인원 제한
+        int maxAllowedActive = 30;
+        List<Queue> newQueueAsActive = queueRepository.findAllByQueueStatus(QueueStatus.ACTIVE);
+        if (newQueueAsActive.size() < maxAllowedActive) {
+            // 제한된 인원(30명)과 ACTIVE 대기열 목록을 비교하여 `ACTIVE`로 변경
+            int searchLimit = maxAllowedActive - newQueueAsActive.size();
+            List<Queue> queuesAsWait = queueRepository.findAllByQueueStatusPerLimit(QueueStatus.WAIT, searchLimit);
+            queuesAsWait.forEach(queue -> queue.changeStatus(QueueStatus.ACTIVE));
+        }
+    }
+
+    private String generateToken() {
+        String uuid = UUID.randomUUID().toString();
+        return uuid.substring(uuid.lastIndexOf("-") + 1);
+    }
+}
+

--- a/src/main/java/com/reservation/ticket/domain/service/ReservationService.java
+++ b/src/main/java/com/reservation/ticket/domain/service/ReservationService.java
@@ -1,0 +1,58 @@
+package com.reservation.ticket.domain.service;
+
+import com.reservation.ticket.domain.command.ReservationCommand;
+import com.reservation.ticket.domain.entity.Reservation;
+import com.reservation.ticket.domain.entity.UserAccount;
+import com.reservation.ticket.domain.enums.PaymentStatus;
+import com.reservation.ticket.domain.enums.ReservationStatus;
+import com.reservation.ticket.domain.repository.ReservationRepository;
+import com.reservation.ticket.domain.repository.UserAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final UserAccountRepository userAccountRepository;
+
+    @Transactional
+    public ReservationCommand.Get save(ReservationCommand.Create create, Long userId) {
+        UserAccount userAccount = userAccountRepository.findById(userId);
+        Reservation reservation = Reservation.of(userAccount, create.price());
+        return ReservationCommand.Get.from(reservationRepository.save(reservation));
+    }
+
+    /**
+     * 예약된 상위 10개의 목록을 조회하여 결재상태가 NOT_PAID 이며, 현재시간보다 5분 초과된 상태면
+     * `ACTIVE`(예약중) 인 상태를 `CANCELLED`(취소) 로 변경한다.
+     */
+    @Transactional
+    public List<Long> changeReservationStatusWhenNotPaidOnTime() {
+        int limit = 10;
+        List<Long> cancelledIds = new ArrayList<>();
+        List<Reservation> reservations =
+                reservationRepository.findAllByReservationStatusOrderByIdAsc(ReservationStatus.ACTIVE, limit);
+        reservations.forEach(reservation -> {
+            if (reservation.getPaymentStatus() == PaymentStatus.NOT_PAID
+                    && reservation.getReservedAt().plusMinutes(5).isBefore(LocalDateTime.now())) {
+                reservation.changeReservationStatus(ReservationStatus.CANCELLED);
+                cancelledIds.add(reservation.getId());
+            }
+        });
+
+        return cancelledIds;
+    }
+
+    public List<Reservation> selectReservationsByReservationStatus(ReservationStatus reservationStatus) {
+        return reservationRepository.findAllByReservationStatus(reservationStatus);
+    }
+
+}
+

--- a/src/main/java/com/reservation/ticket/domain/service/SeatService.java
+++ b/src/main/java/com/reservation/ticket/domain/service/SeatService.java
@@ -1,0 +1,48 @@
+package com.reservation.ticket.domain.service;
+
+import com.reservation.ticket.domain.command.SeatCommand;
+import com.reservation.ticket.domain.entity.Seat;
+import com.reservation.ticket.domain.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SeatService {
+
+    private final SeatRepository seatRepository;
+
+    /**
+     *  콘서트 스케줄 id로 좌석 목록조회
+     */
+    public List<SeatCommand.Get> selectSeatsByConcertScheduleId(Long concertScheduleId) {
+        return seatRepository.findAllByConcertScheduleId(concertScheduleId).stream()
+                .map(SeatCommand.Get::from)
+                .toList();
+    }
+
+    /**
+     *  예약을 기준으로 좌석이 점유되면 occupied 를 false -> ture 변경 및 점유일을 현재시간으로 등록
+     */
+    @Transactional
+    public void changeSeatOccupiedStatus(Long reservationId, List<Long> seatIds) {
+        List<Seat> seats = seatRepository.findByIdIn(seatIds);
+        seats.forEach(seat -> seat.changeToOccupiedAndSaveReservationId(reservationId));
+    }
+
+    @Transactional
+    public void recoverSeatOccupiedStatus(List<Long> cancelledReservationIds) {
+        List<Seat> occupiedSeats = seatRepository.findAllByReservationIdIn(cancelledReservationIds);
+        occupiedSeats.forEach(seat -> seat.releaseOccupiedSeat());
+    }
+
+    public List<SeatCommand.Get> selectSeatsByIds(List<Long> seatIds) {
+        return seatRepository.findByIdIn(seatIds).stream()
+                .map(SeatCommand.Get::from)
+                .toList();
+    }
+}
+

--- a/src/test/java/com/reservation/ticket/application/usecase/ConcertScheduleUsecaseTest.java
+++ b/src/test/java/com/reservation/ticket/application/usecase/ConcertScheduleUsecaseTest.java
@@ -1,0 +1,66 @@
+package com.reservation.ticket.application.usecase;
+
+import com.reservation.ticket.domain.command.ConcertScheduleCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+/**
+ *  콘서트 스케줄 통합 테스트
+ */
+@SpringBootTest
+class ConcertScheduleUsecaseTest {
+
+    @Autowired
+    ConcertScheduleUsecase concertScheduleUsecase;
+
+    @DisplayName("콘서트 id로 예약 날짜를 선택할 수 있는 콘서트 스케줄을 가져온다.")
+    @Test
+    void given_when_then() {
+        // given
+        // 토큰 검증을 위한 userId
+        Long userId = 1L;
+        Long concertId = 1L;
+
+        // when
+        List<ConcertScheduleCommand.Get> concertSchedules =
+                concertScheduleUsecase.selectConcertSchedulesByConcertId(userId, concertId);
+
+        // then
+        assertThat(concertSchedules).isNotEmpty();
+        assertThat(concertSchedules.size()).isEqualTo(3);
+
+        assertThat(concertSchedules)
+                .extracting("openedAt")
+                .containsExactlyInAnyOrder(
+                        tuple(LocalDateTime.of(2024, 7, 9, 9, 33, 40)),
+                        tuple(LocalDateTime.of(2024, 7, 9, 12, 54, 40)),
+                        tuple(LocalDateTime.of(2024, 7, 9, 18, 6, 50))
+                );
+    }
+
+    @DisplayName("콘서트 스케줄 id로 50석의 모든 좌석의 목록을 조회한다.")
+    @Test
+    void givenUserIdAndConcertScheduleId_whenRequestingSeats_thenReturnConcertInfoAndSeats() {
+        // given
+        // 토큰 검증을 위한 userId
+        Long userId = 1L;
+        Long concertId = 1L;
+
+        // when
+        ConcertScheduleCommand.GetForSeats getForSeats = concertScheduleUsecase.selectSeatsByConcertScheduleId(userId, concertId);
+
+        // then
+        int availableSeats = 50;
+        assertThat(getForSeats.seats()).isNotEmpty();
+        assertThat(getForSeats.seats().size()).isEqualTo(availableSeats);
+    }
+
+}

--- a/src/test/java/com/reservation/ticket/application/usecase/ReservationUsecaseTest.java
+++ b/src/test/java/com/reservation/ticket/application/usecase/ReservationUsecaseTest.java
@@ -1,0 +1,82 @@
+package com.reservation.ticket.application.usecase;
+
+import com.reservation.ticket.domain.command.ReservationCommand;
+import com.reservation.ticket.domain.command.SeatCommand;
+import com.reservation.ticket.domain.entity.Reservation;
+import com.reservation.ticket.domain.enums.PaymentStatus;
+import com.reservation.ticket.domain.enums.ReservationStatus;
+import com.reservation.ticket.domain.service.ReservationService;
+import com.reservation.ticket.domain.service.SeatService;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * 예약 통합 테스트
+ */
+@SpringBootTest
+class ReservationUsecaseTest {
+
+    @Autowired
+    ReservationUsecase reservationUsecase;
+    @Autowired
+    ReservationService reservationService;
+    @Autowired
+    SeatService seatService;
+
+    @DisplayName("5분동안 결제가 이루어지지 않은 10개의 예약씩 취소하며, 점유한 좌석도 점유 이전의 상태로 된다.")
+    @Test
+    void given_when_then() {
+        // given
+        int cancelledReservationCount = 0;
+        List<Reservation> reservations = reservationService.selectReservationsByReservationStatus(ReservationStatus.CANCELLED);
+        assertThat(reservations.size()).isEqualTo(cancelledReservationCount);
+
+        // when
+        reservationUsecase.releaseOccupiedSeats();
+
+        // then
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    int cancelledReservationCountScheduled = 10;
+                    List<Reservation> cancelled = reservationService.selectReservationsByReservationStatus(ReservationStatus.CANCELLED);
+                    assertThat(cancelled).isNotEmpty();
+                    assertThat(cancelled.size()).isEqualTo(cancelledReservationCountScheduled);
+                });
+    }
+
+    @DisplayName("예약정보가 주어지면 예약이 이루어지며, 예약한 좌석이 점유된다.")
+    @Test
+    void givenReservationData_whenMakeReservation_thenNothingReturn() {
+        // given
+        int price = 4000;
+        Long concertScheduleId = 1L;
+        List<Long> seats = List.of(1L, 2L, 5L, 8L);
+        ReservationCommand.Create create = ReservationCommand.Create.of(price, concertScheduleId, seats);
+
+        Long userId = 1L;
+
+        // when
+        ReservationCommand.Get reservation = reservationUsecase.makeReservation(create, userId);
+
+        // then
+        assertThat(reservation).isNotNull();
+        assertThat(reservation.paymentStatus()).isEqualTo(PaymentStatus.NOT_PAID);
+        assertThat(reservation.reservationStatus()).isEqualTo(ReservationStatus.ACTIVE);
+
+        // 저장된 좌석을 찾아 검증한다.
+        List<SeatCommand.Get> findSeats = seatService.selectSeatsByIds(seats);
+        assertThat(findSeats).isNotEmpty();
+        assertThat(findSeats.size()).isEqualTo(seats.size());
+    }
+
+}

--- a/src/test/java/com/reservation/ticket/domain/service/ConcertScheduleServiceTest.java
+++ b/src/test/java/com/reservation/ticket/domain/service/ConcertScheduleServiceTest.java
@@ -1,0 +1,58 @@
+package com.reservation.ticket.domain.service;
+
+import com.reservation.ticket.domain.command.ConcertScheduleCommand;
+import com.reservation.ticket.domain.entity.ConcertSchedule;
+import com.reservation.ticket.domain.repository.ConcertScheduleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ConcertScheduleServiceTest {
+
+    @InjectMocks
+    ConcertScheduleService sut;
+
+    @Mock
+    ConcertScheduleRepository concertScheduleRepository;
+
+    @DisplayName("모든 콘서트 스케줄을 가져온다.")
+    @Test
+    void givenConcertId_whenRequestingConcertScheduleList_thenReturnConcertScheduleList() {
+        // given
+
+        // 콘서트 id가 1인 콘서트 스케줄을 전체 검색한다. 기간으로 한달로 변경하면 더욱 좋다.
+        Long concertId = 1L;
+        LocalDateTime concertSchedule1 = LocalDateTime.of(2022, 5, 10, 2, 10);
+        LocalDateTime concertSchedule2 = LocalDateTime.of(2022, 5, 20, 2, 10);
+        List<ConcertSchedule> concertSchedules = List.of(
+                ConcertSchedule.of(1L, 50, concertSchedule1),
+                ConcertSchedule.of(2L, 50, concertSchedule2)
+        );
+        given(concertScheduleRepository.findAllByConcertId(concertId)).willReturn(concertSchedules);
+
+        // when
+        List<ConcertScheduleCommand.Get> schedules = sut.selectAllConcertSchedulesByConcertId(concertId);
+
+        // then
+        assertThat(schedules).isNotNull();
+        assertThat(schedules.size()).isEqualTo(concertSchedules.size());
+        assertThat(schedules)
+                .extracting("id", "limitSeat", "openedAt")
+                .containsExactlyInAnyOrder(
+                        tuple(1L, 50, concertSchedule1),
+                        tuple(2L, 50, concertSchedule2)
+                );
+    }
+
+}

--- a/src/test/java/com/reservation/ticket/domain/service/QueueServiceTest.java
+++ b/src/test/java/com/reservation/ticket/domain/service/QueueServiceTest.java
@@ -1,0 +1,172 @@
+package com.reservation.ticket.domain.service;
+
+import com.reservation.ticket.domain.command.QueueCommand;
+import com.reservation.ticket.domain.entity.Queue;
+import com.reservation.ticket.domain.entity.UserAccount;
+import com.reservation.ticket.domain.enums.QueueStatus;
+import com.reservation.ticket.domain.repository.QueueRepository;
+import com.reservation.ticket.domain.repository.UserAccountRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class QueueServiceTest {
+
+    @InjectMocks
+    QueueService sut;
+    @Mock
+    QueueRepository queueRepository;
+    @Mock
+    UserAccountRepository userAccountRepository;
+
+    /**
+     * 토큰 생성 -
+     */
+    @DisplayName("토큰 생성 - 대기열 생성시에 `대기상태(WAIT)로 저장")
+    @Test
+    void givenUserId_whenActiveQueueIsOver30_thenSaveQueueAsWaitStatus() {
+        // given
+        // userId로 user 검색
+        Long userId = 1L;
+        UserAccount userAccount = UserAccount.of(userId, "Sofia");
+        given(userAccountRepository.findById(userId)).willReturn(userAccount);
+
+        // 대기열 데이터 생성
+        Long queueId = 21L;
+        String token = generateToken();
+
+        Queue savedQueue = Queue.of(queueId, userAccount, token, QueueStatus.WAIT);
+
+        given(queueRepository.save(any(Queue.class))).willReturn(savedQueue);
+
+        // when
+        QueueCommand.Get getQueue = sut.createQueue(userId);
+
+        // then
+        assertThat(getQueue).isNotNull();
+        assertThat(getQueue.id()).isEqualTo(savedQueue.getId());
+        assertThat(getQueue.status()).isEqualTo(QueueStatus.WAIT);
+        assertThat(getQueue.token()).isEqualTo(savedQueue.getToken());
+
+        then(userAccountRepository).should().findById(userId);
+        then(queueRepository).should().save(any(Queue.class));
+    }
+
+    /**
+     * 토큰 검색
+     */
+    @Test
+    void givenToken_whenRequestingQueue_thenReturnQueue() {
+        // given
+        Long userId = 1L;
+        UserAccount userAccount = UserAccount.of(userId, "Sofia");
+        given(userAccountRepository.findById(userId)).willReturn(userAccount);
+
+        String token = userAccount.getToken();
+
+        Long queueId = 21L;
+        Queue queue = Queue.of(queueId, userAccount, token, QueueStatus.ACTIVE);
+        given(queueRepository.findByToken(token)).willReturn(queue);
+
+        // when
+        QueueCommand.Get getQueue = sut.getQueueByUserId(userId);
+
+        // then
+        assertThat(getQueue).isNotNull();
+        assertThat(getQueue.id()).isEqualTo(queueId);
+        assertThat(getQueue.token()).isEqualTo(token);
+        assertThat(getQueue.status()).isEqualTo(QueueStatus.ACTIVE);
+
+        then(userAccountRepository).should().findById(userId);
+        then(queueRepository).should().findByToken(token);
+    }
+
+    /**
+     * 토큰 만료 - 직접만료 -> 구매가 끝남       // 테스트하는 목적이 부정확함 -> 테스트하면 당연히 통과되야되는 구조
+     */
+    @DisplayName("")
+    @Test
+    void givenUserId_whenSearchingQueue_thenExpiredQueueStatus() {
+        // given
+        Long userId = 1L;
+        UserAccount userAccount = UserAccount.of(userId, "Sofia", generateToken());
+        given(userAccountRepository.findById(userId)).willReturn(userAccount);
+
+        Long queueId = 21L;
+        String token = userAccount.getToken();
+        Queue queue = Queue.of(queueId, userAccount, token, QueueStatus.ACTIVE);
+        given(queueRepository.findByToken(token)).willReturn(queue);
+
+        queue.changeStatus(QueueStatus.EXPIRED);
+
+        // when
+        sut.expireQueueByChangingStatus(userId);
+
+        // then
+        assertThat(queue.getQueueStatus()).isEqualTo(QueueStatus.EXPIRED);
+
+        then(userAccountRepository).should().findById(userId);
+        then(queueRepository).should().findByToken(token);
+    }
+
+    /**
+     *
+     */
+    @DisplayName("`ACTIVE` 상태의 대기열이 30개 이하일 때 변경할 대기상태(`WAIT`)의 데이터 목록조회")
+    @Test
+    public void given_when() {
+        // given
+
+        // when
+
+        // then
+    }
+
+    /**
+     * 대기열 만료시간 갱신
+     */
+    @Test
+    void givenTokenInUser_whenRequestingRenewExpireDate_thenRenewExpireDate() {
+        // given
+        // 사용자를 검색하여 토큰을 찾음
+        Long userId = 1L;
+        UserAccount userAccount = UserAccount.of(userId, "Sofia", generateToken());
+        given(userAccountRepository.findById(userId)).willReturn(userAccount);
+
+        // 찾은 토큰으로 대기열 데이터를 가져옴
+        Long queueId = 21L;
+        LocalDateTime shouldExpiredAt = LocalDateTime.of(2024, 7, 10, 10, 10, 5);
+        LocalDateTime createdAt = LocalDateTime.of(2024, 7, 10, 10, 5, 5);
+
+        Queue queue = Queue.of(queueId, userAccount.getToken(), QueueStatus.ACTIVE, shouldExpiredAt, createdAt);
+        given(queueRepository.findByToken(queue.getToken())).willReturn(queue);
+
+        LocalDateTime renewedExpiredAt = LocalDateTime.of(2024, 7, 10, 10, 15, 5);
+        Queue renewedQueue = Queue.of(queueId, userAccount.getToken(), QueueStatus.ACTIVE, renewedExpiredAt, createdAt);
+
+        // when
+        QueueCommand.Get queueCommand = sut.renewExpirationDate(userId);
+
+        // then
+        assertThat(queueCommand).isNotNull();
+        assertThat(queueCommand.shouldExpiredAt()).isEqualTo(renewedQueue.getShouldExpiredAt());
+    }
+
+
+    private String generateToken() {
+        String uuid = UUID.randomUUID().toString();
+        return uuid.substring(uuid.lastIndexOf("-") + 1);
+    }
+}

--- a/src/test/java/com/reservation/ticket/domain/service/scheduler/QueueServiceSchedulerTest.java
+++ b/src/test/java/com/reservation/ticket/domain/service/scheduler/QueueServiceSchedulerTest.java
@@ -1,0 +1,54 @@
+package com.reservation.ticket.domain.service.scheduler;
+
+import com.reservation.ticket.domain.command.QueueCommand;
+import com.reservation.ticket.domain.enums.QueueStatus;
+import com.reservation.ticket.domain.service.QueueService;
+import com.reservation.ticket.infrastructure.config.ScheduledConfig;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Import({ScheduledConfig.class})
+public class QueueServiceSchedulerTest {
+
+    @Autowired
+    private QueueService queueService;
+
+    /**
+     * 토큰 만료 - 만료시간이 경과하여 만료 (스케줄러 테스트)
+     */
+    @DisplayName("스케줄러가 돌며 등록일을 기준으로 5분이 지났을 때 상태값이 `ACTIVE`면 `EXPIRED`로 변경시킨다.")
+    @Test
+    void given_when_then() {
+        // given
+        int activeCount = 28;
+
+        List<QueueCommand.Get> beforeGet = queueService.selectQueueByStatus(QueueStatus.ACTIVE);
+        assertThat(beforeGet).isNotNull();
+        assertThat(beforeGet.size()).isEqualTo(activeCount);
+
+        // when
+        queueService.changeTokenStatusExpired();
+
+        // then
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    List<QueueCommand.Get> gets = queueService.selectQueueByStatus(QueueStatus.ACTIVE);
+
+                    int changeWaitToActiveCount = 15;
+                    assertThat(gets).isNotNull();
+                    assertThat(gets.size()).isEqualTo(changeWaitToActiveCount);
+                });
+    }
+}
+


### PR DESCRIPTION
### 개발이 완료된것과 미완료된것을 구분하였습니다.

### 개발 완료

- 대기열 서비스 및 테스트 작성
   - 설명 : 
       - 대기열의 인원제한은 총 30명입니다.  
       - 모든 사용자는 **WAIT** 상태값을 가지며 대기열 테이블에 데이터가 생성됩니다.  (선착순으로 줄서는 형태입니다.)
       - 스케줄러가 5초마다 동작하여 최초 **WAIT**의 상태 사용자 30명을 **ACTIVE** 로 상태를 변경합니다.
       - 만료일과 현재시간을 비교하여 5분 경과시 **ACTIVE** 상태를 **EXPIRED** 로 변경합니다.
       - **EXPIRED** 로 변경된 대기열 데이터 만큼 **ACTIVE**의 바로 다음 **WAIT** 상태의 데이터를 **ACTIVE** 로 변경합니다.
       - 모든 동작은 하나의 스케줄러에서 5초마다 실행합니다.
   - 파일명 : **QueueService**, **QueueServiceTest** (단위 테스트), **QueueServiceSchedulerTest** (스케줄러 테스트 작성)

<br>

- 예약 날짜 및 예약 좌석를 불러오기 위한 콘서트 스케줄 서비스 및 테스트 작성
    - 설명
        - 예약 날짜
            - 예약 날짜를 조회시 사용자의 id를 이용하여 대기열 토큰 검증 로직 구현했습니다.  (요구사항)
                - (대기열 상태가 **ACTIVE**인지 확인하여 아니면 Exception 발생)
            - 예약 날짜는 기존의 콘서트 스케줄이 가지고 있는 opened_at을 이용하여 해당 콘서트의 콘서트 스케줄의 목록조회로 개발했습니다. (한달 기간을 주어 검색하는 기능은 추후에 추가하려 합니다.) 
        - 예약 좌석
            - 예약 좌석을 조회시에도 사용자의 id를 이용하여 대기열 토큰 검증 로직 구현했습니다. (요구사항)
            - Seat 테이블은 **ConcertScheduleId** 를 가지고 있으며 콘서트 스케줄이 등록될 시, **50**개의 자리가 같이 등록되도록 예상하고 코드를 작성했습니다. 좌석 등록시 ConcertScheduleId 도 같이 저장되도록 했습니다.
            - 그러므로 ConcertScheduleId 를 이용하여 해당 좌석 50개를 검색하도록 했습니다. 
    - 파일명 : **ConcertScheduleUsecase**, **ConsertScheduleUsecaseTest** (통합테스트)
    
<br>

- 예약 요청 서비스 및 테스트 작성
    - 설명
        - 예약 요청시 대기열 토큰 검증합니다.
        - 예약금액이 아직 지불되지 않았으며(**NOT_PAID** 상태), 예약한 시간과 현재시간을 비교하여  5분 경과 시 예약상태를 **ACTIVE (예약중)** 에서 **CANCELLED (예약취소)** 로 변경하였습니다. (스케줄러)
        - 예약이 취소되면 예약과 연관된 좌석은 점유 이전의 상태로 돌아갈수 있도록 구현했습니다.
            - 점유 상태 : Seat 테이블의 **ReservationId**는 해당 예약의 키를 가지며, **occupiedAt**은 점유한 시간, 
            **occupied** = **true**
            - 미점유 상태 : **ReservationId** = **null**, **occupiedAt** = **null**, **occupied** = **false**
    - 파일명 : **ReservationUsecase**, **ReservationUsecaseTest** (통합테스트, 스케줄러 테스트)
 ---
### 개발 필요

- 포인트 충전, 조회
    - 포인트 충전 시 포인트 히스토리 테이블에 데이터를 기록할 예정입니다.
    - 포인트 조회는 사용자 테이블의 포인트를 변경하는 방식으로 진행할 예정입니다.
       - 테이블을 따로 뺄지 고민중입니다. 
- 결재
    -  결제는 포인트로 진행되며 결제가 완료되면 예약의 결제 상태가 **NOT_PAID**에서 **PAID**로 변경하여 예약을 마무리 합니다.
    - 대기열의 상태값도 **ACTIVE** 에서 **EXPIRED** 로 변경합니다.

---

### 리뷰 포인트 
- 이석범 코치님이 주신 다양한 조언으로 대기열 만료 스케줄러 및 예약 시스템, 예약 만료 스케줄러도 잘 구현할 수 있었습니다. 감사합니다!
- 궁금한것은 @Transactional 의 위치입니다. 멘토링 시간에 질문을 드렸지만 Usecase 에 @Transactional을 붙이고 각 서비스 내의 메서드 위에 @Transactional을 붙이니 동작은 잘 되는것을 확인했지만 Transaction이 너무 남발되어 효율적으로 사용하지 못하는거 같습니다. 여기에 대한 조언을 주시면 감사하겠습니다.