### PR TITLE
[Step 16] Transaction 범위를 수정하기 위한 Event 적용 및 외부 API 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.17.7'
 
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.retry:spring-retry-annotations'
+
     //querydsl 설정 추가
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/docs/event.md
+++ b/docs/event.md
@@ -1,0 +1,94 @@
+### Transaction 범위 수정을 위한 Event 적용
+
+목적
+- `PaymentUsecase` 의 `makePayment` 메서드의 Transaction 범위를 수정할 수 있도록 스프링에서 제공하는 Application Event 를 적용함
+
+### 결재 코드수정
+- 결제시 예약의 결제상태 변경, 포인트 차감, 결제정보 저장, 토큰 만료의 과정을 서로 다른 Transaction으로 구성되도록 한다.
+- 예약의 결제상태 변경, 결재정보 저장은 각 도메인의 메서드 내부에서 이루어저며, Active 토큰을 삭제함으로써 만료시킨다.
+- 포인트는 스프링에서 제공하는 이벤트를 사용하여 이벤트 처리하였다. (코드 아래에 이벤트 내용 이어짐)
+- 데이터 플랫폼에 정보 전송 실패시 retry 를 한번 더 할 수 있도록 구성하였다.
+
+```java
+class PaymentUsecase {
+
+    public void makePayment(Long reservationId, String token) {
+        UserAccount userAccount = userAccountService.getUserAccountByToken(token);
+        Reservation reservation = reservationService.getReservation(reservationId);
+        // 예약완료를 위한 결제정보 등록
+        Payment payment = paymentService.createPayment(reservation, userAccount);
+        // 대기열 토큰 검증 및 만료 - redis에 저장된 ACTIVE 토큰 삭제
+        queueRedisService.expire(token);
+
+        /**
+         * 포인트 차감 이벤트
+         *  - 포인트가 예약금액 보다 적다면 예외를 발생시킴
+         */
+        publisher.publishEvent(
+                PointEvent.Use.of(
+                        userAccount.getId(), userAccount.getPoint(), reservation.getPrice(),
+                        reservation.getId(), payment.getId()
+                )
+        );
+
+        // 데이터 플랫폼으로 예약정보 전송
+        callDataPlatform(reservation.getId());
+    }
+
+    /**
+     * 호출시 retry 되도록 함
+     */
+    @Retryable(
+            maxAttempts = 2,                    // 최대 시도 횟수
+            backoff = @Backoff(delay = 1000)    // 재시도 간격
+    )
+    public void callDataPlatform(Long reservationId) {
+        boolean result = dataPlatformClient.send(reservationId);
+        if (!result) {
+            log.warn("data platform send failed");
+        }
+    }
+}
+```
+
+#### 이벤트 적용
+
+- 포인트 차감시 사용자의 포인트보다 예약금액이 초과된다면 예외를 발생시킨다.
+- 발생된 예외를 확인하여 catch 문에서 보상 트랜잭션 이벤트를 발생한다.
+- 이벤트는 payment의 이벤트로 예약의 결재상태 원복, 생성된 결제정보 삭제, 삭제된 Active 토큰 재생성으로 구성된다.
+- 보상 트랜잭션을 이벤트로 처리한 이유는 추후 콘서트, 결제 도메인을 `MSA`로 분리시 처리할 수 있도록 적용했다.
+- 또한 `phase`의 `AFTER_COMMIT`을 적용하여 이벤트를 호출하는 메서드의 처리를 우선하여 보상 트랜잭션이 유효하게 동작하도록 하였다.
+
+```java
+@Component
+@RequiredArgsConstructor
+public class PointListener {
+
+    private final PointService pointService;
+    private final ApplicationEventPublisher publisher;
+
+    /**
+     * 예약금액을 포인트로 차감한다.
+     *  포인트가 부족시 보상 트랜잭션을 발행한다.
+     *      (publish payment recover event - `MSA`를 위해 event 형태로 처리)
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void usePointEvent(PointEvent.Use event) {
+        try {
+            pointService.usePoint(
+                    event.price(), UserAccount.of(event.userId(), event.userPoint())
+            );
+        } catch (Exception e) {
+            publisher.publishEvent(
+                    PaymentEvent.Recover.of(
+                            event.reservationId(),
+                            event.paymentId(),
+                            event.userId()
+                    )
+            );
+            throw e;
+        }
+    }
+
+}
+```

--- a/src/main/java/com/reservation/ticket/application/usecase/PaymentUsecase.java
+++ b/src/main/java/com/reservation/ticket/application/usecase/PaymentUsecase.java
@@ -1,37 +1,70 @@
 package com.reservation.ticket.application.usecase;
 
+import com.reservation.ticket.domain.common.DataPlatformClient;
 import com.reservation.ticket.domain.entity.concert.reservation.Reservation;
-import com.reservation.ticket.domain.entity.concert.reservation.payment.PaymentService;
-import com.reservation.ticket.domain.entity.point.PointService;
-import com.reservation.ticket.domain.entity.userAccount.UserAccount;
 import com.reservation.ticket.domain.entity.concert.reservation.ReservationService;
-import com.reservation.ticket.domain.entity.queue.QueueService;
+import com.reservation.ticket.domain.entity.concert.reservation.payment.Payment;
+import com.reservation.ticket.domain.entity.concert.reservation.payment.PaymentService;
+import com.reservation.ticket.domain.entity.point.event.PointEvent;
+import com.reservation.ticket.domain.entity.queue.QueueRedisService;
+import com.reservation.ticket.domain.entity.userAccount.UserAccount;
 import com.reservation.ticket.domain.entity.userAccount.UserAccountService;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Component
 @RequiredArgsConstructor
 public class PaymentUsecase {
 
+    private static final Logger log = LoggerFactory.getLogger(PaymentUsecase.class);
     private final UserAccountService userAccountService;
-    private final QueueService queueService;
+    private final QueueRedisService queueRedisService;
     private final ReservationService reservationService;
     private final PaymentService paymentService;
-    private final PointService pointService;
 
-    @Transactional
+    public final ApplicationEventPublisher publisher;
+
+    private final DataPlatformClient dataPlatformClient;
+
     public void makePayment(Long reservationId, String token) {
-        // 대기열 토큰 검증 및 만료
-        queueService.expireQueue(token);
-        // 예약의 결제 상태값을 PAID로 변경
-        Reservation reservation = reservationService.changePaymentStatusAsPaid(reservationId);
         UserAccount userAccount = userAccountService.getUserAccountByToken(token);
-        // 포인트 차감 -> 잔액부족이면 예외처리
-        pointService.usePoint(reservation.getPrice(), userAccount);
-        // 결재 생성
-        paymentService.createPayment(reservation, userAccount);
+        Reservation reservation = reservationService.getReservation(reservationId);
+        // 예약완료를 위한 결제정보 등록
+        Payment payment = paymentService.createPayment(reservation, userAccount);
+        // 대기열 토큰 검증 및 만료 - redis에 저장된 ACTIVE 토큰 삭제
+        queueRedisService.expire(token);
+
+        /**
+         * 포인트 차감 이벤트
+         *  - 포인트가 예약금액 보다 적다면 예외를 발생시킴
+         */
+        publisher.publishEvent(
+                PointEvent.Use.of(
+                        userAccount.getId(), userAccount.getPoint(), reservation.getPrice(),
+                        reservation.getId(), payment.getId()
+                )
+        );
+
+        // 데이터 플랫폼으로 예약정보 전송
+        callDataPlatform(reservation.getId());
+    }
+
+    @Retryable(
+        maxAttempts = 2,                    // 최대 시도 횟수
+        backoff = @Backoff(delay = 1000)    // 재시도 간격
+    )
+    public void callDataPlatform(Long reservationId) {
+        boolean result = dataPlatformClient.send(reservationId);
+        if (!result) {
+            log.warn("data platform send failed");
+        }
     }
 
 }

--- a/src/main/java/com/reservation/ticket/domain/common/DataPlatformClient.java
+++ b/src/main/java/com/reservation/ticket/domain/common/DataPlatformClient.java
@@ -1,0 +1,7 @@
+package com.reservation.ticket.domain.common;
+
+public interface DataPlatformClient {
+
+    boolean send(Long id);
+
+}

--- a/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/ReservationService.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/ReservationService.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -72,10 +71,17 @@ public class ReservationService {
         return reservationRepository.findAllByReservationStatus(reservationStatus);
     }
 
-    public Reservation changePaymentStatusAsPaid(Long reservationId) {
+    @Transactional
+    public Reservation getReservation(Long reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId);
         reservation.changePaymentStatus(PaymentStatus.PAID);
         return reservation;
+    }
+
+    @Transactional
+    public void changePaymentStatus(Long reservationId, PaymentStatus paymentStatus) {
+        Reservation reservation = reservationRepository.findById(reservationId);
+        reservation.changePaymentStatus(paymentStatus);
     }
 
     public void checkIfSeatsAvailable(Long concertScheduleId, List<Long> seatIds) {

--- a/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/payment/PaymentRepository.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/payment/PaymentRepository.java
@@ -4,4 +4,5 @@ public interface PaymentRepository {
 
     Payment save(Payment payment);
 
+    void delete(Long paymentId);
 }

--- a/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/payment/PaymentService.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/payment/PaymentService.java
@@ -4,6 +4,7 @@ import com.reservation.ticket.domain.entity.concert.reservation.Reservation;
 import com.reservation.ticket.domain.entity.userAccount.UserAccount;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -11,8 +12,14 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
 
-    public void createPayment(Reservation reservation, UserAccount userAccount) {
+    @Transactional
+    public Payment createPayment(Reservation reservation, UserAccount userAccount) {
         Payment payment = Payment.of(userAccount, reservation);
-        paymentRepository.save(payment);
+        return paymentRepository.save(payment);
     }
+
+    public void deletePayment(Long paymentId) {
+        paymentRepository.delete(paymentId);
+    }
+
 }

--- a/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/payment/event/PaymentEvent.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/payment/event/PaymentEvent.java
@@ -1,0 +1,11 @@
+package com.reservation.ticket.domain.entity.concert.reservation.payment.event;
+
+public class PaymentEvent {
+
+    public record Recover(Long reservationId, Long paymentId, Long userId) {
+        public static Recover of(Long reservationId, Long paymentId, Long userId) {
+            return new Recover(reservationId, paymentId, userId);
+        }
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/payment/event/PaymentListener.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/payment/event/PaymentListener.java
@@ -1,0 +1,27 @@
+package com.reservation.ticket.domain.entity.concert.reservation.payment.event;
+
+import com.reservation.ticket.domain.entity.concert.reservation.ReservationService;
+import com.reservation.ticket.domain.entity.concert.reservation.payment.PaymentService;
+import com.reservation.ticket.domain.entity.queue.QueueRedisService;
+import com.reservation.ticket.domain.enums.PaymentStatus;
+import com.reservation.ticket.domain.enums.QueueStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentListener {
+
+    private final ReservationService reservationService;
+    private final PaymentService paymentService;
+    private final QueueRedisService queueRedisService;
+
+    @EventListener
+    public void recoverFailure(PaymentEvent.Recover event) {
+        reservationService.changePaymentStatus(event.reservationId(), PaymentStatus.NOT_PAID);
+        paymentService.deletePayment(event.paymentId());
+        queueRedisService.recoverQueue(event.userId(), QueueStatus.ACTIVE);
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/domain/entity/point/PointService.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/point/PointService.java
@@ -31,6 +31,7 @@ public class PointService {
     /**
      * 포인트 사용 - 포인트가 결제할 금액보다 작을 경우 예외발생
      */
+    @Transactional
     public void usePoint(int reservedPrice, UserAccount userAccount) {
         if (reservedPrice > userAccount.getPoint()) {
             throw new ApplicationException(ErrorCode.NOT_ENOUGH_POINT,

--- a/src/main/java/com/reservation/ticket/domain/entity/point/event/PointEvent.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/point/event/PointEvent.java
@@ -1,0 +1,11 @@
+package com.reservation.ticket.domain.entity.point.event;
+
+public class PointEvent {
+
+    public record Use(Long userId, int userPoint, int price, Long reservationId, Long paymentId) {
+        public static Use of(Long userId, int userPoint, int price, Long reservationId, Long paymentId) {
+            return new Use(userId, userPoint, price, reservationId, paymentId);
+        }
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/domain/entity/point/event/PointListener.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/point/event/PointListener.java
@@ -1,0 +1,41 @@
+package com.reservation.ticket.domain.entity.point.event;
+
+import com.reservation.ticket.domain.entity.concert.reservation.payment.event.PaymentEvent;
+import com.reservation.ticket.domain.entity.point.PointService;
+import com.reservation.ticket.domain.entity.userAccount.UserAccount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PointListener {
+
+    private final PointService pointService;
+    private final ApplicationEventPublisher publisher;
+
+    /**
+     * 예약금액을 포인트로 차감한다.
+     *  포인트가 부족시 보상 트랜잭션을 발행한다.
+     *      (publish payment recover event - `MSA`를 위해 event 형태로 처리)
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void usePointEvent(PointEvent.Use event) {
+        try {
+            pointService.usePoint(
+                    event.price(), UserAccount.of(event.userId(), event.userPoint())
+            );
+        } catch (Exception e) {
+            publisher.publishEvent(
+                    PaymentEvent.Recover.of(
+                            event.reservationId(),
+                            event.paymentId(),
+                            event.userId()
+                    )
+            );
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/reservation/ticket/domain/entity/queue/QueueRedisService.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/queue/QueueRedisService.java
@@ -32,6 +32,11 @@ public class QueueRedisService {
         return token;
     }
 
+    public void recoverQueue(Long userId, QueueStatus queueStatus) {
+        UserAccount userAccount = userAccountRepository.findById(userId);
+        queueRedisRepository.save(QueueStatement.of(userAccount, userAccount.getToken(), queueStatus));
+    }
+
     public List<QueueCommand.Get> selectQueueByStatus(QueueStatus status) {
         return List.of();
     }
@@ -71,9 +76,12 @@ public class QueueRedisService {
         }
     }
 
+    public void expire(String token) {
+        queueRedisRepository.removeQueue(QueueStatement.of(token, QueueStatus.ACTIVE));
+    }
+
     private String generateToken() {
         String uuid = UUID.randomUUID().toString();
         return uuid.substring(uuid.lastIndexOf("-") + 1);
     }
-
 }

--- a/src/main/java/com/reservation/ticket/domain/entity/userAccount/UserAccount.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/userAccount/UserAccount.java
@@ -54,6 +54,10 @@ public class UserAccount {
         return new UserAccount(id, username);
     }
 
+    public static UserAccount of(Long id, int point) {
+        return new UserAccount(id, null, null, point);
+    }
+
     public static UserAccount of(Long id, String username, String token) {
         return new UserAccount(id, username, token, 0);
     }

--- a/src/main/java/com/reservation/ticket/infrastructure/repository/common/DataPlatformClientImpl.java
+++ b/src/main/java/com/reservation/ticket/infrastructure/repository/common/DataPlatformClientImpl.java
@@ -1,0 +1,19 @@
+package com.reservation.ticket.infrastructure.repository.common;
+
+import com.reservation.ticket.domain.common.DataPlatformClient;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataPlatformClientImpl implements DataPlatformClient {
+
+    @Override
+    public boolean send(Long id) {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/infrastructure/repository/payment/PaymentRepositoryImpl.java
+++ b/src/main/java/com/reservation/ticket/infrastructure/repository/payment/PaymentRepositoryImpl.java
@@ -15,4 +15,10 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     public Payment save(Payment payment) {
         return paymentJpaRepository.save(payment);
     }
+
+    @Override
+    public void delete(Long paymentId) {
+        paymentJpaRepository.deleteById(paymentId);
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,6 +75,6 @@ spring:
   sql.init.mode: always
   data:
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-      password: ${REDIS_PASSWORD}
+      host: 220.88.103.159
+      port: 16379
+      password: oz8109oz

--- a/src/test/java/com/reservation/ticket/domain/entity/point/event/PointListenerTest.java
+++ b/src/test/java/com/reservation/ticket/domain/entity/point/event/PointListenerTest.java
@@ -1,0 +1,50 @@
+package com.reservation.ticket.domain.entity.point.event;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@RecordApplicationEvents
+@SpringBootTest
+class PointListenerTest {
+
+    @Autowired
+    ApplicationEvents applicationEvents;
+
+    @MockBean
+    PointListener pointListener;
+
+    @DisplayName("이벤트를 이용하여 예약금액을 포인트에서 차감한다.")
+    @Test
+    void pointEventTest() {
+        // given
+        Long userId = 1L;
+        int userPoint = 1000;
+        int price = 100;
+        Long reservationId = 1L;
+        Long paymentId = 1L;
+        PointEvent.Use useEvent = PointEvent.Use.of(userId, userPoint, price, reservationId, paymentId);
+
+        // when
+        pointListener.usePointEvent(useEvent);
+
+        // then
+        assertThat(applicationEvents.stream(PointEvent.Use.class))
+                .hasSize(1)
+                .anySatisfy(event -> {
+                    assertAll(
+                            () -> assertThat(event.userId()).isNotNull(),
+                            () -> assertThat(event.reservationId()).isNotNull(),
+                            () -> assertThat(event.paymentId()).isNotNull()
+                    );
+                });
+    }
+
+}

--- a/src/test/java/com/reservation/ticket/domain/service/ReservationServiceTest.java
+++ b/src/test/java/com/reservation/ticket/domain/service/ReservationServiceTest.java
@@ -79,7 +79,7 @@ class ReservationServiceTest {
         given(reservationRepository.findById(reservationId)).willReturn(reservation);
 
         // when
-        Reservation changedReservation = sut.changePaymentStatusAsPaid(reservationId);
+        Reservation changedReservation = sut.getReservation(reservationId);
 
         // then
         assertThat(changedReservation.getPaymentStatus()).isEqualTo(PaymentStatus.PAID);


### PR DESCRIPTION
수정된 기능 : 예약한 콘서트 결제기능
파일 : PaymentUsecase의 makePayment 메서드

[STEP 16 과제 보고서](https://github.com/futuremaker019/ticket-reservation-system/blob/dev/docs/event.md)

#### 수정사항 정리

- 기존
    - 예약결제 상태 변경, 예약금액을 포인트에서 차감, 결제완료 데이터 생성, 토큰 만료
- 수정
    - 예약결제 상태 변경 및 결제완료 데이터 생성 메서드에 각각 Transaction 부여
    - 토큰 만료는 Redis로 처리할 수 있도록 변경
    - 포인트 차감은 스프링 애플리케이션 이벤트로 분리
        - 포인트 부족으로 인한 예외발생 시, 보상 트랜잭션 이벤트를 발생하게 처리하여 보완함
        - 보상트랜잭션에는 예약결제 상태 원복, 생성된 결제완료 데이터 삭제, 삭제된 Active 토큰 생성
        - 파일 
            - 포인트 이벤트 : PointEvent.java , PointListener.java
            - 결제 보상 이벤트 : PaymentEvent.java, PaymentListener.java
    - 데이터 플랫폼에 예약된 id를 전달함
        - 데이터 플랫폼 Timeout을 위한 retry 적용, 2번의 시도를 할 수 있도록 개발
 - 테스트케이스
    - 기존 makePayment 메서드의 테스트를 수정하였습니다.
        - 파일 : PaymentUsecaseTest.java
    - 포인트 이벤트 테스트
        -  파일 : PointEventTest.java

<br>

#### 보완사항
- 생각해보니 포인트 차감 이벤트에서 예외를 발생시키면 데이터 플랫폼에 전송된 정보를 지우는 작업을 하지 못한거 같습니다.
