### PR TITLE
[STEP 17, 18] 카프카 설정 및 테스트, 예약하기 기능개선과 Outbox 패턴을 적용한 미전송된 메시지 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,9 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-    implementation 'org.springframework.kafka:spring-kafka'
+    // test kafka
+    testImplementation 'org.testcontainers:kafka:1.19.3'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
     implementation 'org.springframework.retry:spring-retry'
 
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
     //querydsl 설정 추가
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
@@ -54,6 +57,8 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'org.springframework.kafka:spring-kafka'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/docker/docker-compose-kafka.yml
+++ b/docker/docker-compose-kafka.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/docker/kafka/command-line.md
+++ b/docker/kafka/command-line.md
@@ -1,0 +1,31 @@
+도커에 접속하지 않고 생성하기
+
+```vi
+docker exec -it kafka kafka-topics.sh --bootstrap-server localhost:9092 --create --topic sampleTopic
+
+docker exec -it kafka kafka-console-producer.sh --topic sampleTopic --broker-list 0.0.0.0:9092
+```
+
+카프카 도커에 접속하여 생성하기
+
+```vi
+# Kafka 접속
+docker exec -it kafka bash
+
+# kafka 버전 확인
+kafka-topics.sh --version
+
+# 토픽 생성
+kafka-topics.sh --create --topic sampleTopic1 --bootstrap-server localhost:9092
+
+# 토픽 목록 조회
+kafka-topics.sh --list --bootstrap-server localhost:9092
+```
+
+```vi
+# Producer
+kafka-console-producer.sh --broker-list localhost:9092 --topic test_topic
+
+# Consumer
+kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic test_topic
+```

--- a/src/main/java/com/reservation/ticket/application/event/point/PointEventListener.java
+++ b/src/main/java/com/reservation/ticket/application/event/point/PointEventListener.java
@@ -1,9 +1,8 @@
-package com.reservation.ticket.domain.entity.point.event;
+package com.reservation.ticket.application.event.point;
 
 import com.reservation.ticket.domain.dto.command.PointCommand;
 import com.reservation.ticket.domain.entity.concert.reservation.payment.event.PaymentEvent;
 import com.reservation.ticket.domain.entity.point.PointService;
-import com.reservation.ticket.domain.entity.userAccount.UserAccount;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/reservation/ticket/application/event/reservation/ReservationEventListener.java
+++ b/src/main/java/com/reservation/ticket/application/event/reservation/ReservationEventListener.java
@@ -1,0 +1,43 @@
+package com.reservation.ticket.application.event.reservation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reservation.ticket.domain.common.outbox.OutboxRepository;
+import com.reservation.ticket.domain.entity.concert.reservation.event.ReservationEvent;
+import com.reservation.ticket.domain.entity.concert.reservation.message.ReservationMessage;
+import com.reservation.ticket.domain.entity.concert.reservation.message.ReservationMessageSender;
+import com.reservation.ticket.infrastructure.dto.statement.OutboxStatement;
+import com.reservation.ticket.infrastructure.kafka.KafkaMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationEventListener {
+
+    private final OutboxRepository outboxRepository;
+    private final ReservationMessageSender reservationMessageSender;
+
+    private final ObjectMapper objectMapper;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void saveOutbox(ReservationEvent.Success success) throws JsonProcessingException {
+        ReservationEvent.Get get =
+                ReservationEvent.Get.of(success.reservationId(), success.concertScheduleId(), success.seatIds());
+        String message = objectMapper.writeValueAsString(get);
+        outboxRepository.save(OutboxStatement.Save.of(success.outboxId(), message));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendMessage(ReservationEvent.Success success) {
+        ReservationMessage.Send send
+                = ReservationMessage.Send.of(success.reservationId(), success.concertScheduleId(), success.seatIds());
+        KafkaMessage<ReservationMessage.Send> message = KafkaMessage.of(success.outboxId(), send);
+        reservationMessageSender.send(message);
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/domain/common/outbox/Outbox.java
+++ b/src/main/java/com/reservation/ticket/domain/common/outbox/Outbox.java
@@ -1,0 +1,4 @@
+package com.reservation.ticket.domain.common.outbox;
+
+public class Outbox {
+}

--- a/src/main/java/com/reservation/ticket/domain/common/outbox/OutboxMessageWriter.java
+++ b/src/main/java/com/reservation/ticket/domain/common/outbox/OutboxMessageWriter.java
@@ -1,0 +1,8 @@
+package com.reservation.ticket.domain.common.outbox;
+
+public interface OutboxMessageWriter {
+
+    void complete(String outboxId);
+
+    void resend();
+}

--- a/src/main/java/com/reservation/ticket/domain/common/outbox/OutboxRepository.java
+++ b/src/main/java/com/reservation/ticket/domain/common/outbox/OutboxRepository.java
@@ -1,0 +1,17 @@
+package com.reservation.ticket.domain.common.outbox;
+
+import com.reservation.ticket.domain.enums.OutboxType;
+import com.reservation.ticket.infrastructure.dto.entity.OutboxEntity;
+import com.reservation.ticket.infrastructure.dto.statement.OutboxStatement;
+
+import java.util.List;
+
+public interface OutboxRepository {
+
+    List<OutboxEntity> getOutboxByOutboxType(OutboxType outboxType);
+    OutboxEntity getOutbox(OutboxStatement.Get get);
+
+    OutboxEntity save(OutboxStatement.Save save);
+    void updateStatus(String outboxId, OutboxType outboxType);
+
+}

--- a/src/main/java/com/reservation/ticket/domain/dto/command/ReservationCommand.java
+++ b/src/main/java/com/reservation/ticket/domain/dto/command/ReservationCommand.java
@@ -31,4 +31,10 @@ public class ReservationCommand {
             return new Create(concertScheduleId, seatIds, price);
         }
     }
+
+    public record OccupySeats(Long reservationId, Long concertScheduleId, List<Long> seatIds) {
+        public static OccupySeats of(Long reservationId, Long concertScheduleId, List<Long> seatIds) {
+            return new OccupySeats(reservationId, concertScheduleId, seatIds);
+        }
+    }
 }

--- a/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/event/ReservationEvent.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/event/ReservationEvent.java
@@ -1,0 +1,19 @@
+package com.reservation.ticket.domain.entity.concert.reservation.event;
+
+import java.util.List;
+
+public class ReservationEvent {
+
+    public record Success(String outboxId, Long reservationId, Long concertScheduleId, List<Long> seatIds) {
+        public static Success of(String outboxId, Long reservationId, Long concertScheduleId, List<Long> seatIds) {
+            return new Success(outboxId, reservationId, concertScheduleId, seatIds);
+        }
+    }
+
+    public record Get(Long reservationId, Long concertScheduleId, List<Long> seatIds) {
+        public static Get of(Long reservationId, Long concertScheduleId, List<Long> seatIds) {
+            return new Get(reservationId, concertScheduleId, seatIds);
+        }
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/event/ReservationEventPublisher.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/event/ReservationEventPublisher.java
@@ -1,0 +1,7 @@
+package com.reservation.ticket.domain.entity.concert.reservation.event;
+
+public interface ReservationEventPublisher {
+
+    void successReservation(ReservationEvent.Success success);
+
+}

--- a/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/message/ReservationMessage.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/message/ReservationMessage.java
@@ -1,0 +1,18 @@
+package com.reservation.ticket.domain.entity.concert.reservation.message;
+
+import java.util.List;
+
+public class ReservationMessage {
+
+    public record Send(Long reservationId, Long concertScheduleId, List<Long> seatIds) {
+        public static Send of(Long reservationId, Long concertScheduleId, List<Long> seatIds) {
+            return new Send(reservationId, concertScheduleId, seatIds);
+        }
+    }
+
+    public record Get(Long id, Long reservationId, Long concertScheduleId, List<Long> seatIds) {
+        public static Get of(Long id, Long reservationId, Long concertScheduleId, List<Long> seatIds) {
+            return new Get(id, reservationId, concertScheduleId, seatIds);
+        }
+    }
+}

--- a/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/message/ReservationMessageSender.java
+++ b/src/main/java/com/reservation/ticket/domain/entity/concert/reservation/message/ReservationMessageSender.java
@@ -1,0 +1,11 @@
+package com.reservation.ticket.domain.entity.concert.reservation.message;
+
+import com.reservation.ticket.infrastructure.kafka.KafkaMessage;
+
+public interface ReservationMessageSender {
+
+    void send(KafkaMessage<ReservationMessage.Send> message);
+
+    void sendMessage(KafkaMessage<String> message);
+
+}

--- a/src/main/java/com/reservation/ticket/domain/enums/LockType.java
+++ b/src/main/java/com/reservation/ticket/domain/enums/LockType.java
@@ -2,6 +2,6 @@ package com.reservation.ticket.domain.enums;
 
 public enum LockType {
 
-    NONE, PESSIMISTIC_READ, DISTRIBUTED_LOCK
+    NONE, PESSIMISTIC_READ, DISTRIBUTED_LOCK, PESSIMISTIC_WRITE
 
 }

--- a/src/main/java/com/reservation/ticket/domain/enums/OutboxType.java
+++ b/src/main/java/com/reservation/ticket/domain/enums/OutboxType.java
@@ -1,0 +1,7 @@
+package com.reservation.ticket.domain.enums;
+
+public enum OutboxType {
+
+    INIT, PUBLISHED
+
+}

--- a/src/main/java/com/reservation/ticket/infrastructure/dto/entity/OutboxEntity.java
+++ b/src/main/java/com/reservation/ticket/infrastructure/dto/entity/OutboxEntity.java
@@ -1,0 +1,49 @@
+package com.reservation.ticket.infrastructure.dto.entity;
+
+import com.reservation.ticket.domain.enums.OutboxType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OutboxEntity {
+
+    @Id
+    private String id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10) DEFAULT 'INIT' COMMENT '메시지 전송상태'")
+    private OutboxType outboxType;
+
+    @Column(columnDefinition = "LONGTEXT COMMENT '메시지'")
+    private String message;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    void createdAt() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    void updatedAt() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public OutboxEntity(String id, OutboxType outboxType, String message) {
+        this.id = id;
+        this.outboxType = outboxType;
+        this.message = message;
+    }
+
+    public static OutboxEntity of(String id, OutboxType outboxType, String message) {
+        return new OutboxEntity(id, outboxType, message);
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/infrastructure/dto/statement/OutboxStatement.java
+++ b/src/main/java/com/reservation/ticket/infrastructure/dto/statement/OutboxStatement.java
@@ -1,0 +1,16 @@
+package com.reservation.ticket.infrastructure.dto.statement;
+
+public class OutboxStatement {
+
+    public record Save(String id, String message) {
+        public static Save of(String id, String message) {
+            return new Save(id, message);
+        }
+    }
+
+    public record Get(String id) {
+        public static Get of(String id) {
+            return new Get(id);
+        }
+    }
+}

--- a/src/main/java/com/reservation/ticket/infrastructure/kafka/KafkaMessage.java
+++ b/src/main/java/com/reservation/ticket/infrastructure/kafka/KafkaMessage.java
@@ -1,0 +1,22 @@
+package com.reservation.ticket.infrastructure.kafka;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KafkaMessage<T> {
+
+    private String id;
+    private T message;
+
+    public KafkaMessage(String id, T message) {
+        this.id = id;
+        this.message = message;
+    }
+
+    public static <T> KafkaMessage<T> of(String id, T message) {
+        return new KafkaMessage<>(id, message);
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/infrastructure/kafka/reservation/ReservationKafkaMessageSender.java
+++ b/src/main/java/com/reservation/ticket/infrastructure/kafka/reservation/ReservationKafkaMessageSender.java
@@ -1,0 +1,30 @@
+package com.reservation.ticket.infrastructure.kafka.reservation;
+
+import com.reservation.ticket.domain.entity.concert.reservation.message.ReservationMessage;
+import com.reservation.ticket.domain.entity.concert.reservation.message.ReservationMessageSender;
+import com.reservation.ticket.infrastructure.kafka.KafkaMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationKafkaMessageSender implements ReservationMessageSender {
+
+    @Value("${kafka.topic.name}")
+    private String TOPIC_NAME;
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void send(KafkaMessage<ReservationMessage.Send> message) {
+        kafkaTemplate.send(TOPIC_NAME, message);
+    }
+
+    @Override
+    public void sendMessage(KafkaMessage<String> message) {
+        kafkaTemplate.send(TOPIC_NAME, message);
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/infrastructure/repository/common/OutboxJpaRepository.java
+++ b/src/main/java/com/reservation/ticket/infrastructure/repository/common/OutboxJpaRepository.java
@@ -1,0 +1,20 @@
+package com.reservation.ticket.infrastructure.repository.common;
+
+import com.reservation.ticket.domain.enums.OutboxType;
+import com.reservation.ticket.infrastructure.dto.entity.OutboxEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface OutboxJpaRepository extends JpaRepository<OutboxEntity, String> {
+
+    List<OutboxEntity> findAllByOutboxType(OutboxType outboxType);
+
+    @Modifying
+    @Query("UPDATE OutboxEntity o SET o.outboxType = :outboxType, o.updatedAt = now() WHERE o.id = :outboxId")
+    void update(@Param("outboxId") String outboxId, @Param("outboxType") OutboxType outboxType);
+
+}

--- a/src/main/java/com/reservation/ticket/infrastructure/repository/common/OutboxMessageWriterImpl.java
+++ b/src/main/java/com/reservation/ticket/infrastructure/repository/common/OutboxMessageWriterImpl.java
@@ -1,0 +1,44 @@
+package com.reservation.ticket.infrastructure.repository.common;
+
+import com.reservation.ticket.domain.common.outbox.OutboxMessageWriter;
+import com.reservation.ticket.domain.common.outbox.OutboxRepository;
+import com.reservation.ticket.domain.entity.concert.reservation.message.ReservationMessage;
+import com.reservation.ticket.domain.entity.concert.reservation.message.ReservationMessageSender;
+import com.reservation.ticket.domain.enums.OutboxType;
+import com.reservation.ticket.infrastructure.dto.entity.OutboxEntity;
+import com.reservation.ticket.infrastructure.kafka.KafkaMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxMessageWriterImpl implements OutboxMessageWriter {
+
+    private final OutboxRepository outboxRepository;
+    private final ReservationMessageSender messageSender;
+
+
+    @Override
+    @Transactional
+    public void complete(String outboxId) {
+        outboxRepository.updateStatus(outboxId, OutboxType.PUBLISHED);
+    }
+
+    @Override
+    public void resend() {
+        List<OutboxEntity> outboxes = outboxRepository.getOutboxByOutboxType(OutboxType.INIT);
+        if (!outboxes.isEmpty()) {
+            outboxes.forEach(outbox -> {
+                if (outbox.getCreatedAt().plusMinutes(5).isBefore(LocalDateTime.now())) {
+                    KafkaMessage<String> message = KafkaMessage.of(outbox.getId(), outbox.getMessage());
+                    messageSender.sendMessage(message);
+                }
+            });
+        }
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/infrastructure/repository/common/OutboxRepositoryImpl.java
+++ b/src/main/java/com/reservation/ticket/infrastructure/repository/common/OutboxRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.reservation.ticket.infrastructure.repository.common;
+
+import com.reservation.ticket.domain.common.outbox.OutboxRepository;
+import com.reservation.ticket.domain.enums.OutboxType;
+import com.reservation.ticket.domain.exception.ApplicationException;
+import com.reservation.ticket.domain.exception.ErrorCode;
+import com.reservation.ticket.infrastructure.dto.entity.OutboxEntity;
+import com.reservation.ticket.infrastructure.dto.statement.OutboxStatement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public OutboxEntity save(OutboxStatement.Save statement) {
+        OutboxEntity outbox = OutboxEntity.of(statement.id(), OutboxType.INIT, statement.message());
+        return outboxJpaRepository.save(outbox);
+    }
+
+    @Override
+    public OutboxEntity getOutbox(OutboxStatement.Get get) {
+        return outboxJpaRepository.findById(get.id()).orElseThrow(
+                () -> new ApplicationException(ErrorCode.CONTENT_NOT_FOUND, "Outbox not found : %s".formatted(get.id())));
+    }
+
+    @Override
+    public void updateStatus(String outboxId, OutboxType outboxType) {
+        outboxJpaRepository.update(outboxId, outboxType);
+    }
+
+    @Override
+    public List<OutboxEntity> getOutboxByOutboxType(OutboxType outboxType) {
+        return outboxJpaRepository.findAllByOutboxType(outboxType);
+    }
+
+
+}

--- a/src/main/java/com/reservation/ticket/infrastructure/repository/ticket/TicketJpaRepository.java
+++ b/src/main/java/com/reservation/ticket/infrastructure/repository/ticket/TicketJpaRepository.java
@@ -14,7 +14,7 @@ public interface TicketJpaRepository extends JpaRepository<Ticket, TicketComplex
 
     List<Ticket> findAllByIdConcertScheduleIdAndIdSeatIdIn(Long concertScheduleId, List<Long> seats);
 
-    @Lock(LockModeType.PESSIMISTIC_READ)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "1500"))
     @Query("select t from Ticket t where t.id.concertScheduleId = :concertScheduleId and t.id.seatId in :seats")
     List<Ticket> findAllWithPessimisticLock(@Param("concertScheduleId") Long concertScheduleId, @Param("seats") List<Long> seats);

--- a/src/main/java/com/reservation/ticket/infrastructure/spring/reservation/ReservationSpringEventPublisher.java
+++ b/src/main/java/com/reservation/ticket/infrastructure/spring/reservation/ReservationSpringEventPublisher.java
@@ -1,0 +1,20 @@
+package com.reservation.ticket.infrastructure.spring.reservation;
+
+import com.reservation.ticket.domain.entity.concert.reservation.event.ReservationEvent;
+import com.reservation.ticket.domain.entity.concert.reservation.event.ReservationEventPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationSpringEventPublisher implements ReservationEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void successReservation(ReservationEvent.Success success) {
+        eventPublisher.publishEvent(success);
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/interfaces/consumer/reservation/ReservationMessageConsumer.java
+++ b/src/main/java/com/reservation/ticket/interfaces/consumer/reservation/ReservationMessageConsumer.java
@@ -1,0 +1,57 @@
+package com.reservation.ticket.interfaces.consumer.reservation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reservation.ticket.domain.common.outbox.OutboxMessageWriter;
+import com.reservation.ticket.domain.dto.command.ReservationCommand;
+import com.reservation.ticket.domain.entity.concert.reservation.ReservationService;
+import com.reservation.ticket.infrastructure.kafka.KafkaMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.concurrent.CountDownLatch;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationMessageConsumer {
+
+    private final ReservationService reservationService;
+
+    private final ObjectMapper objectMapper;
+    private final OutboxMessageWriter outboxMessageWriter;
+
+    private CountDownLatch latch = new CountDownLatch(1);
+    private String payload;
+
+    @KafkaListener(topics = "${kafka.topic.name}", groupId = "group1")
+    public void complete(KafkaMessage<?> get) {
+        outboxMessageWriter.complete(get.getId());
+    }
+
+    @KafkaListener(topics = "${kafka.topic.name}", groupId = "group2")
+    public void occupySeats(KafkaMessage<?> get) {
+        LinkedHashMap<?, ?> map = (LinkedHashMap<?, ?>) get.getMessage();
+        ReservationCommand.OccupySeats occupySeats = objectMapper.convertValue(map, ReservationCommand.OccupySeats.class);
+        reservationService.occupySeats(occupySeats);
+    }
+
+    @KafkaListener(topics = "${kafka.topic.name}", groupId = "group3")
+    public void testConsumer(KafkaMessage<?> get) {
+        payload = get.getId();
+        latch = new CountDownLatch(1);
+    }
+
+    public void resetLatch() {
+        latch = new CountDownLatch(1);
+    }
+
+    public String getPayload() {
+        return this.payload;
+    }
+    public CountDownLatch getLatch() {
+        return this.latch;
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/interfaces/scheduler/SchedulerManager.java
+++ b/src/main/java/com/reservation/ticket/interfaces/scheduler/SchedulerManager.java
@@ -1,8 +1,8 @@
 package com.reservation.ticket.interfaces.scheduler;
 
 import com.reservation.ticket.application.usecase.ReservationUsecase;
+import com.reservation.ticket.domain.common.outbox.OutboxMessageWriter;
 import com.reservation.ticket.domain.entity.queue.QueueRedisService;
-import com.reservation.ticket.domain.entity.queue.QueueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -13,6 +13,7 @@ public class SchedulerManager {
 
     private final QueueRedisService queueRedisService;
     private final ReservationUsecase reservationUsecase;
+    private final OutboxMessageWriter outboxMessageWriter;
 
     @Scheduled(cron = "5 * * * * *", zone = "Asia/Seoul")
     public void activateQueueScheduler() {
@@ -27,6 +28,11 @@ public class SchedulerManager {
     @Scheduled(cron = "5 * * * * *", zone = "Asia/Seoul")
     public void activateReservationScheduler() {
         reservationUsecase.cancelReservation();
+    }
+
+    @Scheduled(cron = "5 * * * * *", zone = "Asia/Seoul")
+    public void resendMessage() {
+        outboxMessageWriter.resend();
     }
 
 }

--- a/src/main/java/com/reservation/ticket/support/annotation/CurrentUser.java
+++ b/src/main/java/com/reservation/ticket/support/annotation/CurrentUser.java
@@ -1,4 +1,4 @@
-package com.reservation.ticket.domain.annotation;
+package com.reservation.ticket.support.annotation;
 
 import java.lang.annotation.*;
 

--- a/src/main/java/com/reservation/ticket/support/config/AsyncConfig.java
+++ b/src/main/java/com/reservation/ticket/support/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.reservation.ticket.support.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig extends AsyncConfigurerSupport {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("concert-async-");
+        executor.initialize();
+        return executor;
+    }
+    }
+}

--- a/src/main/java/com/reservation/ticket/support/config/AsyncConfig.java
+++ b/src/main/java/com/reservation/ticket/support/config/AsyncConfig.java
@@ -1,7 +1,9 @@
 package com.reservation.ticket.support.config;
 
+import com.reservation.ticket.support.config.exception.CustomAsyncUncaughtExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -9,7 +11,7 @@ import java.util.concurrent.Executor;
 
 @EnableAsync
 @Configuration
-public class AsyncConfig extends AsyncConfigurerSupport {
+public class AsyncConfig implements AsyncConfigurer {
 
     @Override
     public Executor getAsyncExecutor() {
@@ -21,5 +23,10 @@ public class AsyncConfig extends AsyncConfigurerSupport {
         executor.initialize();
         return executor;
     }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new CustomAsyncUncaughtExceptionHandler();
     }
+
 }

--- a/src/main/java/com/reservation/ticket/support/config/KafkaConfig.java
+++ b/src/main/java/com/reservation/ticket/support/config/KafkaConfig.java
@@ -1,9 +1,11 @@
 package com.reservation.ticket.support.config;
 
+import com.reservation.ticket.infrastructure.kafka.KafkaMessage;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
@@ -17,10 +19,13 @@ import java.util.Map;
 @Configuration
 public class KafkaConfig {
 
+    @Value("${kafka.bootstrap-server}")
+    private String BOOTSTRAP_SERVER;
+
     @Bean
     public ProducerFactory<String, Object> producerFactory() {
         Map<String, Object> config = new HashMap<>();
-        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVER);
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
 
@@ -33,20 +38,21 @@ public class KafkaConfig {
     }
 
     @Bean
-    public ConsumerFactory<String, Object> consumerFactory() {
+    public ConsumerFactory<String, KafkaMessage<?>> consumerFactory() {
         Map<String, Object> config = new HashMap<>();
 
-        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        config.put(ConsumerConfig.GROUP_ID_CONFIG, "concert-group-1");
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVER);
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
 
-        return new DefaultKafkaConsumerFactory<>(config);
+        return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(), new JsonDeserializer<>(KafkaMessage.class), false);
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    public ConcurrentKafkaListenerContainerFactory<String, KafkaMessage<?>> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, KafkaMessage<?>> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
 
         return factory;

--- a/src/main/java/com/reservation/ticket/support/config/KafkaConfig.java
+++ b/src/main/java/com/reservation/ticket/support/config/KafkaConfig.java
@@ -1,0 +1,55 @@
+package com.reservation.ticket.support.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaProducerTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "concert-group-1");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(config);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+
+        return factory;
+    }
+
+}

--- a/src/main/java/com/reservation/ticket/support/config/exception/CustomAsyncUncaughtExceptionHandler.java
+++ b/src/main/java/com/reservation/ticket/support/config/exception/CustomAsyncUncaughtExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.reservation.ticket.support.config.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Component
+public class CustomAsyncUncaughtExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.warn(ex.getMessage(), ex);
+        log.warn("async exception method name: {}", method.getName());
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ spring:
     group:
       local:
         - common
+      test:
+        - common
 
 ---
 
@@ -29,6 +31,10 @@ springdoc:
     disable-swagger-default-url: true
     display-request-duration: true
     operations-sorter: alpha
+
+kafka:
+  topic.name: concert-topic-1
+  bootstrap-server: localhost:9092
 
 ---
 
@@ -75,6 +81,6 @@ spring:
   sql.init.mode: always
   data:
     redis:
-      host: 220.88.103.159
-      port: 16379
-      password: oz8109oz
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -480,3 +480,9 @@ values (1, null, false),
        (5, null, false),
        (5, null, false),
        (5, null, false);
+
+insert into outbox_entity (`id`, message, outbox_type, created_at) values
+       ('548c3433f7ac', '{"reservationId":51,"concertScheduleId":1,"seatIds":[5,6]}', 'INIT', '2024-08-16 00:25:05'),
+       ('448c3433f7ac', '{"reservationId":51,"concertScheduleId":1,"seatIds":[7,8]}', 'INIT', '2024-08-16 00:25:05'),
+       ('348c3433f7ac', '{"reservationId":51,"concertScheduleId":1,"seatIds":[9,10]}', 'INIT', '2024-08-16 00:25:05'),
+       ('248c3433f7ac', '{"reservationId":51,"concertScheduleId":1,"seatIds":[11,12]}', 'INIT', '2024-08-16 00:25:05');

--- a/src/test/java/com/reservation/ticket/application/usecase/ReservationUsecaseTest.java
+++ b/src/test/java/com/reservation/ticket/application/usecase/ReservationUsecaseTest.java
@@ -3,9 +3,15 @@ package com.reservation.ticket.application.usecase;
 import com.reservation.ticket.application.dto.criteria.ReservationCriteria;
 import com.reservation.ticket.application.dto.result.ReservationResult;
 import com.reservation.ticket.domain.dto.command.SeatCommand;
+import com.reservation.ticket.domain.dto.info.ReservationInfo;
+import com.reservation.ticket.domain.entity.concert.reservation.Reservation;
+import com.reservation.ticket.domain.entity.concert.reservation.ReservationRepository;
 import com.reservation.ticket.domain.entity.concert.reservation.SeatService;
 import com.reservation.ticket.domain.enums.PaymentStatus;
 import com.reservation.ticket.domain.enums.ReservationStatus;
+import com.reservation.ticket.infrastructure.dto.statement.OutboxStatement;
+import com.reservation.ticket.infrastructure.repository.common.OutboxRepositoryImpl;
+import com.reservation.ticket.infrastructure.repository.reservation.ReservationRepositoryImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,8 +27,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 class ReservationUsecaseTest {
 
-    @Autowired ReservationUsecase reservationUsecase;
+    @Autowired ReservationUsecase sut;
+
     @Autowired SeatService seatService;
+    @Autowired ReservationRepositoryImpl reservationRepository;
+    @Autowired OutboxRepositoryImpl outboxRepository;
 
     @DisplayName("예약정보가 주어지면 예약이 이루어지며, 선택한 좌석이 점유된다.")
     @Test
@@ -35,7 +44,7 @@ class ReservationUsecaseTest {
         ReservationCriteria criteria = ReservationCriteria.of(concertScheduleId, seats, price);
 
         // when
-        ReservationResult reservation = reservationUsecase.makeReservation(criteria, token);
+        ReservationResult reservation = sut.makeReservation(criteria, token);
 
         // then
         assertThat(reservation).isNotNull();
@@ -46,6 +55,25 @@ class ReservationUsecaseTest {
         List<SeatCommand.Get> findSeats = seatService.selectSeatsByIds(seats);
         assertThat(findSeats).isNotEmpty();
         assertThat(findSeats.size()).isEqualTo(seats.size());
+    }
+
+    @DisplayName("예약하고 좌석 점유를 위해 메시지를 보내고 outbox 저장")
+    @Test
+    void test02() {
+        // given
+        int price = 4000;
+        Long concertScheduleId = 1L;
+        List<Long> seats = List.of(5L, 8L);
+        String token = "734488355d85";
+        ReservationCriteria criteria = ReservationCriteria.of(concertScheduleId, seats, price);
+
+        // when
+        ReservationInfo reservationInfo = sut.makeReservationSendingMessage(criteria, token);
+
+        // then
+        Reservation reservation = reservationRepository.findById(reservationInfo.id());
+        assertThat(reservation).isNotNull();
+        assertThat(reservation.getPrice()).isEqualTo(price);
     }
 
 }

--- a/src/test/java/com/reservation/ticket/domain/entity/point/event/PointEventListenerTest.java
+++ b/src/test/java/com/reservation/ticket/domain/entity/point/event/PointEventListenerTest.java
@@ -1,5 +1,6 @@
 package com.reservation.ticket.domain.entity.point.event;
 
+import com.reservation.ticket.application.event.point.PointEventListener;
 import com.reservation.ticket.domain.entity.concert.reservation.Reservation;
 import com.reservation.ticket.domain.entity.concert.reservation.payment.Payment;
 import com.reservation.ticket.domain.entity.concert.reservation.payment.event.PaymentEvent;

--- a/src/test/java/com/reservation/ticket/infrastructure/repository/common/OutboxRepositoryImplTest.java
+++ b/src/test/java/com/reservation/ticket/infrastructure/repository/common/OutboxRepositoryImplTest.java
@@ -1,0 +1,54 @@
+package com.reservation.ticket.infrastructure.repository.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reservation.ticket.domain.entity.concert.reservation.event.ReservationEvent;
+import com.reservation.ticket.domain.enums.OutboxType;
+import com.reservation.ticket.infrastructure.dto.entity.OutboxEntity;
+import com.reservation.ticket.infrastructure.dto.statement.OutboxStatement;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class OutboxRepositoryImplTest {
+
+    @Autowired
+    private OutboxRepositoryImpl repository;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("예약 id, 콘서트 스케줄 id, 좌석 ids를 메시지로 한 outbox를 저장 후, 저장된 id를 이용하여 메시지 및 메시지 상태를 확인한다.")
+    @Test
+    void test01() throws JsonProcessingException {
+        // given
+        Long reservationId = 1L;
+        Long concertScheduleId = 1L;
+        List<Long> seatIds = List.of(1L, 2L);
+        String outboxId = "734488355d85";
+        OutboxType type = OutboxType.INIT;
+
+        ReservationEvent.Success success = ReservationEvent.Success.of(outboxId, reservationId, concertScheduleId, seatIds);
+        String message = objectMapper.writeValueAsString(success);
+
+        // when
+        OutboxEntity save = repository.save(OutboxStatement.Save.of(outboxId, message));
+
+        // then
+        OutboxEntity outbox = repository.getOutbox(OutboxStatement.Get.of(save.getId()));
+        assertThat(outbox).isNotNull();
+        assertThat(outbox.getOutboxType()).isEqualTo(type);
+
+        ReservationEvent.Success converted = objectMapper.readValue(message, ReservationEvent.Success.class);
+        assertThat(converted).isNotNull();
+        assertThat(converted.reservationId()).isEqualTo(reservationId);
+        assertThat(converted.seatIds()).isEqualTo(seatIds);
+        assertThat(converted.concertScheduleId()).isEqualTo(concertScheduleId);
+    }
+
+}

--- a/src/test/java/com/reservation/ticket/interfaces/scheduler/OutboxSchedulerTest.java
+++ b/src/test/java/com/reservation/ticket/interfaces/scheduler/OutboxSchedulerTest.java
@@ -1,0 +1,53 @@
+package com.reservation.ticket.interfaces.scheduler;
+
+import com.reservation.ticket.domain.enums.OutboxType;
+import com.reservation.ticket.infrastructure.dto.entity.OutboxEntity;
+import com.reservation.ticket.infrastructure.repository.common.OutboxRepositoryImpl;
+import com.reservation.ticket.support.config.ScheduledConfig;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Import({ScheduledConfig.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class OutboxSchedulerTest {
+
+    @Autowired
+    SchedulerManager schedulerManager;
+
+    @Autowired
+    OutboxRepositoryImpl outboxRepository;
+
+    @DisplayName("5분이 경과된 outbox 데이터 중 'INIT' 상태인 데이터를 다시 메시지로 전송하여 'PUBLISHED'로 변경한다.")
+    @Test
+    void test01() {
+        // given
+        int initMessages = 4;
+        List<OutboxEntity> outboxes = outboxRepository.getOutboxByOutboxType(OutboxType.INIT);
+        assertThat(outboxes.size()).isEqualTo(initMessages);
+
+        // when
+        schedulerManager.resendMessage();
+
+        // then
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    int publishedMessages = 4;
+                    List<OutboxEntity> changedOutboxes = outboxRepository.getOutboxByOutboxType(OutboxType.PUBLISHED);
+                    assertThat(changedOutboxes).isNotEmpty();
+                    assertThat(changedOutboxes.size()).isEqualTo(publishedMessages);
+                });
+    }
+
+}

--- a/src/test/java/com/reservation/ticket/kafka/EmbeddedKafkaIntegratedTest.java
+++ b/src/test/java/com/reservation/ticket/kafka/EmbeddedKafkaIntegratedTest.java
@@ -1,0 +1,53 @@
+package com.reservation.ticket.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reservation.ticket.domain.entity.concert.reservation.message.ReservationMessage;
+import com.reservation.ticket.infrastructure.kafka.KafkaMessage;
+import com.reservation.ticket.infrastructure.kafka.reservation.ReservationKafkaMessageSender;
+import com.reservation.ticket.interfaces.consumer.reservation.ReservationMessageConsumer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@DirtiesContext
+@EmbeddedKafka(partitions = 1, brokerProperties = { "listeners=PLAINTEXT://localhost:9092", "port=9092" })
+public class EmbeddedKafkaIntegratedTest {
+
+    @Autowired
+    ReservationKafkaMessageSender messageSender;
+
+    @Autowired
+    ReservationMessageConsumer messageConsumer;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void test01() throws InterruptedException {
+        // given
+        String outboxId = "248c3433f7ac";
+        Long reservationId = 1L;
+        Long concertScheduleId = 1L;
+        List<Long> seatIds = List.of(5L, 6L);
+        ReservationMessage.Send send
+                = ReservationMessage.Send.of(reservationId, concertScheduleId, seatIds);
+        KafkaMessage<ReservationMessage.Send> message = KafkaMessage.of(outboxId, send);
+
+        // when
+        messageSender.send(message);
+
+        // then
+        messageConsumer.getLatch().await(5, TimeUnit.SECONDS);
+        assertThat(messageConsumer.getPayload()).isEqualTo(outboxId);
+    }
+
+}


### PR DESCRIPTION
과제 두개가 하나로 합쳐졌네요.. 죄송합니다.

아래와 같이 개발하였으며 파일명도 추가하였습니다.

### Kafka 적용된 기능

- 예약하기 기능에서 예약 후 예약정보를 Kafka 메시지로 전송하여 자리를 선점하는 방식으로 개발했습니다.
- 좌석선점 시의 동시성을 Kafka로 제어하고자 예약하기 기능을 선택했습니다.
- 파일명 : ReservationUsecase, ReservationService

### ApplicationEvent 

- 트랜잭션을 관리하는 리스너는 `/application`  Layer에 위치시키는 것이 맞다고 판단했습니다. 조언 감사드립니다, 석범코치님!

|            | 위치                                       | 파일명                                                      | 비고 |
|------------|------------------------------------------|----------------------------------------------------------|----|
| 이벤트        | /domain/entity/concert/reservation/event | - ReservationEvent <br> - ReservationEventPublisher (IF) |    |
| 리스너        | /application/event/reservation           | - ReservationEventListener                               |    |
| 퍼블리셔 (구현체) | /infrastructure/spring/reservation       | - ReservationSpringEventPublisher                        |    |

### Kafka
    
|                | 위치                                         | 파일명                                                       | 비고 |
|----------------|--------------------------------------------|-----------------------------------------------------------|----|
| Kafka 설정       | /support/config                            | KafkaConfig                                               |    |
| Async 설정       | /support/config                            | - AsyncConfig <br> - CustomAsyncUncaughtExceptionHandler  |    |
| Kafka producer | /domain/entity/concert/reservation/message | - ReservationMessage <br> - ReservationMessageSender (IF) |    |
|                | /infrastructure/kafka/reservation          | - ReservationKafkaMessageSender <br> - KafkaMessage       |    |
| Kafka consumer | /interfaces/consumer/reservation           | - ReservationMessageConsumer                              |    |
| 테스트 |  /interfaces/consumer/reservation           | - EmbeddedKafkaIntegratedTest                              |    |

### Outbox
   - 도메인과 엔티티를 분리하여 적용하려 했으나 이번에는 적용하지 못했습니다. 그래서 Outbox.java 파일이 비어있는 상태입니다.

|      | 위치                                | 파일명                                                                                                  | 비고                    |
|------|-----------------------------------|------------------------------------------------------------------------------------------------------|-----------------------|
| 도메인  | /domain/common/outbox             | - Outbox <br> - OutboxMessageWriter (IF) <br> - OutboxRepository  (IF)                                        |                       |
| 인프라  | /infrastructure/repository/common | - OutboxEntity <br> - OutboxJpaRepository <br> - OutboxMessageWriterImpl <br> - OutboxRepositoryImpl |                       |
| 스케줄러 | /interfaces/scheduler             | - SchedulerManager                                                                                   | - 메서드 : resendMessage |
| 테스트  |                                   | - OutboxRepositoryImplTest <br> - OutboxSchedulerTest                                                |                       |

### 아쉬운 점
- 좌석이 점유된 상태인지를 검증하는 부분에서 비관적락을 적용하여 예약이 중복되는것을 방지해야 했던 부분을 실수한거 같습니다.
- Consumer 로 전달받은 예약정보를 이용하여 좌석 점유 시, 점유된 좌석인지를 확인하여 점유 시, 보상 트랜잭션 메시지 발행하여 예약된 정보를 삭제하는 로직을 추가하지 못했습니다. 
- Kafka 테스트 시, TestContainer를 적용하여 격리된 인프라 상태에서 테스트를 진행해보고자 했지만 설정이 제대로 되지 않아 실패헸습니다. 다시 적용해보고자 합니다.